### PR TITLE
Fixed URL regex

### DIFF
--- a/Tests/ConvertTo-IRM.ps1
+++ b/Tests/ConvertTo-IRM.ps1
@@ -1,0 +1,47 @@
+
+ . "$PSScriptRoot\..\src\public\ConvertTo-IRM.ps1"
+
+describe "Testin ConvertTo-IRM"{
+
+    $TestCase1 = @{}
+    $TestCase1.CURL = "curl -X GET https://PlopServer/identity/api/tenants/Woo/subtenants -H 'Accept: application/json' -H 'Authorization: Bearer {{token}}'"
+    $TestCase1.IRME = @"
+Invoke-RestMethod -Method GET https://PlopServer/identity/api/tenants/Woo/subtenants -Headers ('{"Accept":"application/json","Authorization":"Bearer {{token}}"}' | ConvertFrom-Json)
+"@
+    
+    $TestCase2 = @{}
+    $TestCase2.CURL ="curl -X GET 'https://{{vRA-FQDN}}/catalog-service/api/consumer/entitledCatalogItems?page=1&limit=1000' -H 'Accept: application/json' -H 'Authorization: Bearer {{token}}'"
+    $TestCase2.IRME = @"
+Invoke-RestMethod -Method GET 'https://{{vRA-FQDN}}/catalog-service/api/consumer/entitledCatalogItems?page=1&limit=1000' -Headers ('{"Accept":"application/json","Authorization":"Bearer {{token}}"}' | ConvertFrom-Json)
+"@
+
+$TestCases = @($TestCase1,$TestCase2)
+
+    Context "Correct URL cases" {
+        IT 'When passed correct CURL command it should return correct invoke-restmethod'{
+            Param(
+                $CURL,$IRME
+            )
+
+            ConvertTo-IRM -CurlString $CURL | Should be $IRME
+
+        } -TestCases $TestCases
+
+    }
+    Context "Incorect URL Cases"{
+        It "Incorrect URL should not be converted" {
+
+            $Url = "curl -X GET 'https://////plop' -H 'Accept: application/json' -H 'Authorization: Bearer {{token}}'"  
+            #What to do in this case? 
+        } -Skip
+          
+    }
+}
+
+<#
+
+
+
+ 
+
+#>

--- a/src/public/ConvertTo-IRM.ps1
+++ b/src/public/ConvertTo-IRM.ps1
@@ -24,7 +24,7 @@ Function ConvertTo-IRM {
     # Match the url
     # regex from: https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
     # I added a comma in the case of multiple parameter values in uri.
-    $Null = $CurlString -match '^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=\/]{2,256}(\.[a-z]{2,6}\b)|([-a-zA-Z0-9@:%_\+.~#?&\/\/=,]*)'
+    $Null = $CurlString -match 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=\/]{2,256}(\.[a-z]{2,6}\b)|([-a-zA-Z0-9@:%_\+.~#?&\/\/=,]*)'
     $url = $Matches[0]
 
     $escapedUrl = [regex]::Escape($url)

--- a/src/public/ConvertTo-IRM.ps1
+++ b/src/public/ConvertTo-IRM.ps1
@@ -78,9 +78,3 @@ Function ConvertTo-IRM {
     $outString += " -Headers ('$($headers | ConvertTo-Json -Compress)' | ConvertFrom-Json)"
     $outString
 }
-
-$CurlCommand = @"
-curl -X GET https://PlopServer/identity/api/tenants/Woo/subtenants -H 'Accept: application/json' -H 'Authorization: Bearer {{token}}'
-"@
-
-ConvertTo-IRM -CurlString $CurlCommand

--- a/src/public/ConvertTo-IRM.ps1
+++ b/src/public/ConvertTo-IRM.ps1
@@ -1,4 +1,18 @@
 Function ConvertTo-IRM {
+    <#
+    .SYNOPSIS
+        Converts a CURL command to a Invoke-RestMethod command
+    .DESCRIPTION
+        
+    .EXAMPLE
+        
+    .INPUTS
+        Inputs (if any)
+    .OUTPUTS
+        Output (if any)
+    .NOTES
+        v:0.2
+    #>
     param (
         [ValidateScript({$_.ToLower() -match '^curl '})]
         [string]$CurlString
@@ -10,7 +24,7 @@ Function ConvertTo-IRM {
     # Match the url
     # regex from: https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
     # I added a comma in the case of multiple parameter values in uri.
-    $CurlString -match 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=,]*)'
+    $Null = $CurlString -match '^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=\/]{2,256}(\.[a-z]{2,6}\b)|([-a-zA-Z0-9@:%_\+.~#?&\/\/=,]*)'
     $url = $Matches[0]
 
     $escapedUrl = [regex]::Escape($url)
@@ -64,3 +78,9 @@ Function ConvertTo-IRM {
     $outString += " -Headers ('$($headers | ConvertTo-Json -Compress)' | ConvertFrom-Json)"
     $outString
 }
+
+$CurlCommand = @"
+curl -X GET https://PlopServer/identity/api/tenants/Woo/subtenants -H 'Accept: application/json' -H 'Authorization: Bearer {{token}}'
+"@
+
+ConvertTo-IRM -CurlString $CurlCommand


### PR DESCRIPTION
Salutation!

Fixed #1 

The regex was built in a way, that if you had an url without .XXX, it would not correctly parse the string.
I also added a pester test with 2 test cases.

Another thing that poped into my mind, is how do you want to handle wrong urls. Like: http:/// for example? Throw an error, or simply return $null? (I have pre-prepared a pester test for that too).

I also added a (very) short comment based help. As this is not (yet?) a module, there was no 'versioning'. You can see I added a version in the .NOTES section of the comment based help.

Cheers

ps: You only have the master branch, so I couldn't do the PR to a dev branch.