### PR TITLE
Validate curl.exe

### DIFF
--- a/src/classes/CurlCommand.ps1
+++ b/src/classes/CurlCommand.ps1
@@ -20,8 +20,8 @@ Class CurlCommand {
         $this.Method = 'Get'
 
         $splitParams = Invoke-Command -ScriptBlock ([scriptblock]::Create("parse $curlString"))
-        if ($splitParams[0].ToLowerInvariant() -ne 'curl') {
-            Throw "`$curlString does not start with 'curl', which is necessary for correct parsing."
+        if ($splitParams[0] -notin 'curl', 'curl.exe') {
+            Throw "`$curlString does not start with 'curl' or 'curl.exe', which is necessary for correct parsing."
         }
         for ($x = 1; $x -lt $splitParams.Count; $x++) {
             # If this item is a parameter name, use it

--- a/src/public/Get-CurlCommand.ps1
+++ b/src/public/Get-CurlCommand.ps1
@@ -1,7 +1,7 @@
 Function Get-CurlCommand {
     [OutputType([CurlCommand])]
     param (
-        [ValidateScript({ $_.ToLowerInvariant().Trim() -match '^curl ' })]
+        [ValidateScript({ $_.Trim() -match '^curl(?:\.exe)? ' })]
         [string]$CurlString
     )
     [CurlCommand]::new($CurlString.Trim())


### PR DESCRIPTION
Couldn't figure out why the command wasn't working for me at first, but then I realized it was because it doesn't recognize `curl.exe`

Also, `.ToLowerInvariant()` isn't necessary for PowerShell's native comparison operators unless they're prepended with `c` (e.g. `-ceq`, `-cnotin`, `-cmatch`, etc.) so I removed that from the comparisons.